### PR TITLE
Fix NullPointerException with deposit/withdraw methods

### DIFF
--- a/src/main/java/ca/tweetzy/funds/hooks/VaultHook.java
+++ b/src/main/java/ca/tweetzy/funds/hooks/VaultHook.java
@@ -148,15 +148,15 @@ public final class VaultHook implements Economy {
 		if (account == null || currency == null)
 			return new EconomyResponse(0D, 0D, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "Funds vault currency not set or user account not found!");
 
-		if (account.getCurrencies().get(currency) < amount) {
-			return new EconomyResponse(0D, account.getCurrencies().get(currency), EconomyResponse.ResponseType.FAILURE, null);
+		final double currentBalance = account.getCurrencies().getOrDefault(currency, 0D);
+		if (currentBalance < amount) {
+			return new EconomyResponse(0D, currentBalance, EconomyResponse.ResponseType.FAILURE, null);
 		}
 
-		final double currentBalance = account.getCurrencies().get(currency);
 		account.getCurrencies().put(currency, currentBalance - amount);
 		account.sync(true);
 
-		return new EconomyResponse(amount, account.getCurrencies().get(currency), EconomyResponse.ResponseType.SUCCESS, null);
+		return new EconomyResponse(amount, currentBalance, EconomyResponse.ResponseType.SUCCESS, null);
 	}
 
 	@Override
@@ -172,15 +172,15 @@ public final class VaultHook implements Economy {
 		if (account == null || currency == null)
 			return new EconomyResponse(0D, 0D, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "Funds vault currency not set or user account not found!");
 
-		if (account.getCurrencies().get(currency) < amount) {
-			return new EconomyResponse(0D, account.getCurrencies().get(currency), EconomyResponse.ResponseType.FAILURE, null);
+		final double currentBalance = account.getCurrencies().getOrDefault(currency, 0D);
+		if (currentBalance < amount) {
+			return new EconomyResponse(0D, currentBalance, EconomyResponse.ResponseType.FAILURE, null);
 		}
 
-		final double currentBalance = account.getCurrencies().get(currency);
 		account.getCurrencies().put(currency, currentBalance - amount);
 		account.sync(true);
 
-		return new EconomyResponse(amount, account.getCurrencies().get(currency), EconomyResponse.ResponseType.SUCCESS, null);
+		return new EconomyResponse(amount, currentBalance, EconomyResponse.ResponseType.SUCCESS, null);
 	}
 
 	@Override
@@ -198,11 +198,11 @@ public final class VaultHook implements Economy {
 			return new EconomyResponse(0D, 0D, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "Funds vault currency not set or user account not found!");
 
 
-		final double currentBalance = account.getCurrencies().get(currency);
+		final double currentBalance = account.getCurrencies().getOrDefault(currency, 0D);
 		account.getCurrencies().put(currency, currentBalance + amount);
 		account.sync(true);
 
-		return new EconomyResponse(amount, account.getCurrencies().get(currency), EconomyResponse.ResponseType.SUCCESS, null);
+		return new EconomyResponse(amount, currentBalance, EconomyResponse.ResponseType.SUCCESS, null);
 	}
 
 	@Override
@@ -219,11 +219,11 @@ public final class VaultHook implements Economy {
 			return new EconomyResponse(0D, 0D, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "Funds vault currency not set or user account not found!");
 
 
-		final double currentBalance = account.getCurrencies().get(currency);
+		final double currentBalance = account.getCurrencies().getOrDefault(currency, 0D);
 		account.getCurrencies().put(currency, currentBalance + amount);
 		account.sync(true);
 
-		return new EconomyResponse(amount, account.getCurrencies().get(currency), EconomyResponse.ResponseType.SUCCESS, null);
+		return new EconomyResponse(amount, currentBalance, EconomyResponse.ResponseType.SUCCESS, null);
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes a NullPointerException present in all deposit/withdraw methods in the Vault hook when a users has an unspecified amount of currency (generally 0). The account's currencies map will not contain an entry if the value is 0 or the currency otherwise doesn't exist, but no caution is exhibited with 0 balanced currencies.

Exception raised via VeinMiner as a proxy:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Double.doubleValue()" because the return value of "java.util.Map.get(Object)" is null
    at Funds.jar/ca.tweetzy.funds.hooks.VaultHook.withdrawPlayer(VaultHook.java:151) ~[Funds.jar:?]
    at VeinMiner-Bukkit-2.2.5.jar/wtf.choco.veinminer.economy.SimpleVaultEconomy.withdraw(SimpleVaultEconomy.java:57) ~[VeinMiner-Bukkit-2.2.5.jar:?]
    at VeinMiner-Bukkit-2.2.5.jar/wtf.choco.veinminer.listener.BreakBlockListener.onBlockBreak(BreakBlockListener.java:110) ~[VeinMiner-Bukkit-2.2.5.jar:?]
    at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:40) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
    at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:1.21.1-83-2aaf436]
    at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
    at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
    at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:383) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.level.ServerPlayerGameMode.destroyAndAck(ServerPlayerGameMode.java:342) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:306) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1856) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:51) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:20) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:56) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:151) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1537) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:201) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:125) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1514) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1507) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:135) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1466) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1473) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1318) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:330) ~[paper-1.21.1.jar:1.21.1-83-2aaf436]
    at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
The `hasBalance()` was cautious, but VeinMiner was (incorrectly) calling `withdrawPlayer()` with an amount of 0, which is how this exception is raised. VeinMiner calling upon the economy's withdraw functions with 0 [has been fixed separately](https://github.com/2008Choco/VeinMiner/commit/162692b330265e306b94706ed19ffa6092671d2b), but I still feel that Funds can be more cautious about this :)